### PR TITLE
Specify that IE edge mode should be used as the rendering engine.

### DIFF
--- a/app/public/smart/finrisk-calculator/index.html
+++ b/app/public/smart/finrisk-calculator/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <script src="https://rawgithub.com/dchester/jsonpath/master/jsonpath.min.js"></script>
     <script src="https://rawgithub.com/smart-on-fhir/client-js/master/dist/fhir-client.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.2.3/jquery.min.js"></script>

--- a/app/public/smart/finrisk-calculator/launch.html
+++ b/app/public/smart/finrisk-calculator/launch.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <script src="https://rawgithub.com/smart-on-fhir/client-js/master/dist/fhir-client.js"></script>
     <script>
         FHIR.oauth2.authorize({


### PR DESCRIPTION
In an embedded IE browser, the default rendering engine is IE 7.
As such, the webpage must instruct the browser as to the actual
rendering engine. By specifying IE edge, we ensure that the latest
rendering engine is used.
